### PR TITLE
Include required Foundation header

### DIFF
--- a/Init.x
+++ b/Init.x
@@ -1,4 +1,5 @@
 #import <dlfcn.h>
+#import <Foundation/Foundation.h>
 
 extern void initSideloadedFixes();
 

--- a/SideloadedFixes.x
+++ b/SideloadedFixes.x
@@ -1,4 +1,5 @@
 #import <mach-o/dyld.h>
+#import <Foundation/Foundation.h>
 
 // Make keychain accesses and application group accesses work on sideloaded Instagram
 


### PR DESCRIPTION
This small PR fixes the error below, which can occur when patching, by adding the required `<Foundation/Foundation.h>` header to tweak files. Special thanks to [Mikasa-san](https://github.com/Mikasa-san)!

```zsh
Init.x:7:12: error: use of undeclared identifier 'NSBundle'
        dlopen([[[NSBundle mainBundle].bundlePath stringByAppendingPathComponent:@"Frameworks/InstagramAppCoreFramework.framework/InstagramAppCoreFramework"] UTF8String], RTLD_NOW);
```